### PR TITLE
Run deployment GHA with pixi environment

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -1,48 +1,41 @@
-# This file was created automatically with `myst init --gh-pages` 🪄 💚
-# Ensure your GitHub Pages settings for this repository are set to deploy with **GitHub Actions**.
-
-name: MyST GitHub Pages Deploy
+name: "MyST GitHub Pages Deploy"
 on:
   push:
-    # Runs on pushes targeting the default branch
-    branches: [main]
-env:
-  # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
-  # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.
-  # If, instead, your site lives at the root of the domain, at `https://mydomain.org`, set `BASE_URL=''`.
-  BASE_URL: /${{ github.event.repository.name }}
+    branches: ["main"]
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: 'pages'
-  cancel-in-progress: false
+  cancel-in-progress: true
+
+env:
+  BASE_URL: "/${{ github.event.repository.name }}"
+
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+  build:
+    runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - uses: actions/setup-node@v4
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - uses: "prefix-dev/setup-pixi@v0.8.8"
+
+      - run: "pixi run render"
+
+      - name: "Upload site artifact"
+        uses: "actions/upload-pages-artifact@v3"
         with:
-          node-version: 18.x
-      - name: Install MyST
-        run: npm install -g mystmd
-      - name: Build HTML Assets
-        run: myst build --html
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './_build/html'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          path: "./_build/html"
+
+  deploy:
+    runs-on: "ubuntu-latest"
+    needs: "build"
+    environment:
+      name: "github-pages"
+      url: "${{ steps.deployment.outputs.page_url }}"
+    permissions:
+      pages: "write"
+      id-token: "write"
+    steps:
+      - name: "Deploy to GitHub Pages"
+        id: "deployment"
+        uses: "actions/deploy-pages@v4"


### PR DESCRIPTION
Resolves #4 for real this time

I rewrote the out-of-the-box GitHub Actions deployment to use the pixi environment so our listings plugin can work. It depends on pandas. Which is probably not what we want to do long-term. We should probably switch to https://github.com/ryanlovett/myst-listing-plugin instead of my copy-pasted Python plugin :grin: 

<!-- readthedocs-preview jupyter-community-committee start -->
---
:mag: Preview: https://jupyter-community-committee--7.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupyter-community-committee end -->