### PR TITLE
Add 2024 community survey to programming page

### DIFF
--- a/programming.md
+++ b/programming.md
@@ -13,3 +13,10 @@ growing the community of contributors, and strengthening collaborations.
 ## Community calls
 
 Virtual events to communicate between subprojects and with the Jupyter user community as a whole.
+
+
+## Community surveys
+
+Taking the pulse of the Jupyter community and its needs!
+
+* 2024: [Community Building Report](https://blog.jupyter.org/community-building-report-project-jupyter-5a0fd7c8b08d)

--- a/programming.md
+++ b/programming.md
@@ -19,6 +19,6 @@ Virtual events to communicate between subprojects and with the Jupyter user comm
 
 ## Community surveys
 
-Taking the pulse of the Jupyter community and its needs! The JCB periodically surveys Jupyter community members and uses your input to prioritize next actions. 2024's survey prompted us to focus on community programming. 
+Taking the pulse of the Jupyter community and its needs! The JCB periodically surveys Jupyter community members and uses your input to prioritize next actions. 2024's survey prompted us to focus on community programming.
 
 * 2024: [Community Building Report](https://blog.jupyter.org/community-building-report-project-jupyter-5a0fd7c8b08d)

--- a/programming.md
+++ b/programming.md
@@ -9,6 +9,8 @@ documented on this page and promoted via the Jupyter Media Strategy working grou
 In-person and virtual events for tackling challenging development and design projects,
 growing the community of contributors, and strengthening collaborations.
 
+* 2026: <https://events.linuxfoundation.org/jupyter-workshops/>
+
 
 ## Community calls
 

--- a/programming.md
+++ b/programming.md
@@ -17,6 +17,6 @@ Virtual events to communicate between subprojects and with the Jupyter user comm
 
 ## Community surveys
 
-Taking the pulse of the Jupyter community and its needs!
+Taking the pulse of the Jupyter community and its needs! The JCB periodically surveys Jupyter community members and uses your input to prioritize next actions. 2024's survey prompted us to focus on community programming. 
 
 * 2024: [Community Building Report](https://blog.jupyter.org/community-building-report-project-jupyter-5a0fd7c8b08d)


### PR DESCRIPTION


<!-- readthedocs-preview jupyter-community-committee start -->
---
:mag: Preview: https://jupyter-community-committee--16.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupyter-community-committee end -->